### PR TITLE
Remove unused permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "name": "Christian Ponte",
         "url": "https://github.com/chponte/google-scholar-search-engine"
     },
-    "version": "1.0",
+    "version": "1.2",
     "chrome_settings_overrides": {
         "search_provider": {
             "name": "Google Scholar",

--- a/manifest.json
+++ b/manifest.json
@@ -18,8 +18,7 @@
         }
     },
     "permissions": [
-        "contextMenus",
-        "tabs"
+        "contextMenus"
     ],
     "background": {
         "scripts": [


### PR DESCRIPTION
Hi, I noticed the `tabs` permission is not necessary and prompts at install to “Access browser tabs”.

With this PR the install is not asking for that permission anymore, the add-on is still fully functional (context menu and search engine), and the privileged part of the Tabs API (urls…) is not available to the add-on anymore which was a security risk.